### PR TITLE
Use HTTPS for readiness probe

### DIFF
--- a/mi-dashboard/templates/mi-dashboard-deployment.yaml
+++ b/mi-dashboard/templates/mi-dashboard-deployment.yaml
@@ -86,6 +86,7 @@ spec:
             httpGet:
               path: /dashboard/api/healthz
               port: {{ .Values.wso2.config.serverPort }}
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.probes.readiness.periodSeconds }}
           resources:


### PR DESCRIPTION
## Purpose

The MI Dashboard health check endpoint `/dashboard/api/healthz` is exposed via `9743` which supports only HTTPS. Therefore we need to use HTTPS for readiness probe.

**Note**: Since we redirect HTTP to HTTPS in v4.2.0, this fix is to add support to MI Dashboard 4.1.0.