### PR TITLE
Add option to pass params to properties file

### DIFF
--- a/mi/CONFIG.md
+++ b/mi/CONFIG.md
@@ -60,6 +60,7 @@ A Helm chart for the deployment of WSO2 Micro Integrator
 | wso2.config.dashboard.heartbeatInterval | int | `5` | The time interval (in seconds) between two heartbeats sent from the Micro Integrator to the dashboard server |
 | wso2.config.dashboard.nodeId | string | pod name | The node ID of the Micro Integrator deployment |
 | wso2.config.dashboard.url | string | `""` | MI Dashboard URL |
+| wso2.config.fileProperties | list | `nil` | List of properties |
 | wso2.config.keyStore.internal.alias | string | `"wso2carbon"` | Internal keystore alias |
 | wso2.config.keyStore.internal.fileName | string | `"wso2carbon.jks"` | Internal keystore file name |
 | wso2.config.keyStore.internal.keyPassword | string | `""` | Internal keystore key password |

--- a/mi/EXAMPLES.md
+++ b/mi/EXAMPLES.md
@@ -275,6 +275,18 @@ wso2:
       class: "org.wso2.carbon.test.gateway.SecHandler"
 ```
 
+## Adding properties to configuration file.
+
+You can use a configuration file to load the parameter values to the properties file stored in the <MI_HOME>/conf directory, which you can use to store the parameter values that should be injected to your synapse configuration.
+
+```yaml
+wso2:
+  config:
+    fileProperties:
+      prop1: value1
+      prop2: value2
+```
+
 ## Defining a custom message formatter
 
 Similar configurations can be used to define a custom message builder as well. Refer `wso2.config.messageFormatters` and `wso2.config.messageBuilders` sections in [CONFIG](./CONFIG.md).

--- a/mi/templates/mi-deployment.yaml
+++ b/mi/templates/mi-deployment.yaml
@@ -192,6 +192,11 @@ spec:
               mountPath: /home/wso2carbon/wso2-config-volume/conf/security/secret-conf.properties
               subPath: secret-conf.properties
             {{- end }}
+            {{- if .Values.wso2.config.fileProperties }}
+            - name: wso2mi-file-properties
+              mountPath: /home/wso2carbon/wso2-config-volume/conf/file.properties
+              subPath: file.properties
+            {{- end }}
       volumes:
         - name: wso2mi-toml
           configMap:
@@ -235,4 +240,9 @@ spec:
         - name: wso2mi-secret-properties
           configMap:
             name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-mi-secret-properties
+        {{- end }}
+        {{- if .Values.wso2.config.fileProperties }}
+        - name: wso2mi-file-properties
+          configMap:
+            name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-mi-file-properties
         {{- end }}

--- a/mi/templates/mi-file-prop-conf.yaml
+++ b/mi/templates/mi-file-prop-conf.yaml
@@ -1,0 +1,24 @@
+
+{{- if .Values.wso2.config.fileProperties }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-mi-file-properties
+  namespace : {{ .Release.Namespace }}
+data:
+  file.properties: |-
+{{- range $key, $value := .Values.wso2.config.fileProperties }}
+    {{ $key }}={{ $value }}
+{{- end }}
+{{- end }}

--- a/mi/values_full.yaml
+++ b/mi/values_full.yaml
@@ -567,6 +567,8 @@ wso2:
         tokenConfig:
           expiry: 3600
           size: 2048
+    # -- (list) List of properties
+    fileProperties:
   deployment:
     securityContext:
       # -- Enable/Disable AppArmor (https://kubernetes.io/docs/tutorials/security/apparmor/)


### PR DESCRIPTION
## Purpose
Add option to pass params to properties file.

You can use a configuration file to load the parameter values to the properties file stored in the `<MI_HOME>/conf` directory, which you can use to store the parameter values that should be injected to your synapse configuration.

```yaml
wso2:
  config:
    fileProperties:
      prop1: value1
      prop2: value2
```