### PR TITLE
Add option to pass synapse properties from helm values

### DIFF
--- a/mi/CONFIG.md
+++ b/mi/CONFIG.md
@@ -121,6 +121,7 @@ A Helm chart for the deployment of WSO2 Micro Integrator
 | wso2.config.serviceCatalog.password | string | `""` | Password for signing in to the API Manager runtime |
 | wso2.config.serviceCatalog.username | string | `""` | User name for signing in to the API Manager runtime |
 | wso2.config.synapseHandlers | list | `[{"class":"","name":""}]` | List of synapse handlers with the name and the implementation class |
+| wso2.config.synapseProperties | list | `nil` | List of synapse properties |
 | wso2.config.transport.http.blocking.listener.enable | bool | `true` |  |
 | wso2.config.transport.http.blocking.listener.hostname | string | `""` |  |
 | wso2.config.transport.http.blocking.listener.originServer | string | `""` |  |

--- a/mi/EXAMPLES.md
+++ b/mi/EXAMPLES.md
@@ -287,6 +287,17 @@ wso2:
       prop2: value2
 ```
 
+## Defining synapse properties
+For commonly used synapse properties you can use the properties under `wso2.config.mediation.synapse` in the Helm values. If you need to pass any other parameter to the `synapse.properties` file you need to define them under `wso2.config.synapseProperties` as follows,
+
+```yaml
+wso2:
+  config:
+    synapseProperties:
+      synapse.json.to.xml.processing.instruction.enabled: true
+      freemarker.template.base.path: '"/home/test"'
+```
+
 ## Defining a custom message formatter
 
 Similar configurations can be used to define a custom message builder as well. Refer `wso2.config.messageFormatters` and `wso2.config.messageBuilders` sections in [CONFIG](./CONFIG.md).

--- a/mi/confs/deployment.toml
+++ b/mi/confs/deployment.toml
@@ -279,6 +279,13 @@ password = {{ .Values.wso2.config.serviceCatalog.password | quote }}
 {{- end }}
 {{- end }}
 
+{{ if .Values.wso2.config.synapseProperties }}
+[synapse_properties]
+{{- range $key, $value := .Values.wso2.config.synapseProperties }}
+{{ $key | squote }} = {{ $value }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.wso2.config.mediation }}
 [mediation]
 {{- if .Values.wso2.config.mediation.synapse }}

--- a/mi/values_full.yaml
+++ b/mi/values_full.yaml
@@ -476,6 +476,8 @@ wso2:
       sequenceAnalytics: true
       # -- Enable/Disable publishing endpoint analytics data
       endpointAnalytics: true
+    # -- (list) List of synapse properties
+    synapseProperties:
     # -- (list) List of synapse handlers with the name and the implementation class
     synapseHandlers:
     - name: ""


### PR DESCRIPTION
## Purpose
Add option to pass synapse properties from helm values.

For commonly used synapse properties you can use the properties under `wso2.config.mediation.synapse` in the Helm values. If you need to pass any other parameter to the `synapse.properties` file you need to define them under `wso2.config.synapseProperties` as follows,

```yaml
wso2:
  config:
    synapseProperties:
      synapse.json.to.xml.processing.instruction.enabled: true
      freemarker.template.base.path: '"/home/test"'
```