### PR TITLE
Update helm chart to support WSO2 MI 4.3.0.

### DIFF
--- a/mi/auth.json
+++ b/mi/auth.json
@@ -1,0 +1,10 @@
+{
+	"auths": {
+		"reg.id": {
+			"username": "reg.username",
+			"password": "reg.password",
+			"email": "reg.email",
+			"auth": "reg.auth"
+		}
+	}
+}

--- a/mi/templates/mi-deployment.yaml
+++ b/mi/templates/mi-deployment.yaml
@@ -65,7 +65,7 @@ spec:
                 topologyKey: topology.kubernetes.io/zone
       containers:
         - name: wso2mi
-          image: {{ .Values.containerRegistry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}
+          image: {{ .Values.containerRegistry }}/{{ .Values.wso2.deployment.image.repository }}{{- if .Values.wso2.deployment.image.digest }}@{{ .Values.wso2.deployment.image.digest }}{{- else }}:{{ .Values.wso2.deployment.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.wso2.deployment.image.pullPolicy }}
           args:
             {{- if .Values.wso2.deployment.synapseTest.enabled }}
@@ -114,10 +114,10 @@ spec:
               protocol: TCP
             - containerPort: {{ add 9164 .Values.wso2.config.portOffset -10 }}
               protocol: TCP
-          {{- if .Values.wso2.deployment.synapseTest.enabled }}
+            {{- if .Values.wso2.deployment.synapseTest.enabled }}
             - containerPort: {{ add 9008 .Values.wso2.config.portOffset -10 }}
               protocol: TCP
-          {{- end }}
+            {{- end }}
           env:
             - name: JAVA_MEM_OPTS
               value: "-Xms{{ .Values.wso2.deployment.resources.jvm.memory.xms }} -Xmx{{ .Values.wso2.deployment.resources.jvm.memory.xmx }}"
@@ -126,12 +126,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          {{- if .Values.wso2.deployment.envs }}
+            {{- if .Values.wso2.deployment.envs }}
             {{- range $key, $val := .Values.wso2.deployment.envs }}
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-          {{- end }}
+            {{- end }}
           volumeMounts:
             - name: wso2mi-toml
               mountPath: /home/wso2carbon/wso2-config-volume/conf/deployment.toml
@@ -246,3 +246,10 @@ spec:
           configMap:
             name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-mi-file-properties
         {{- end }}
+      {{- if .Values.wso2.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.wso2.deployment.imagePullSecrets }}
+      {{- else if and .Values.wso2.subscription.username .Values.wso2.subscription.password }}
+      imagePullSecrets:
+        - name: wso2micro-integrator-deployment-creds
+      {{- end }}

--- a/mi/templates/mi-deployment.yaml
+++ b/mi/templates/mi-deployment.yaml
@@ -65,7 +65,7 @@ spec:
                 topologyKey: topology.kubernetes.io/zone
       containers:
         - name: wso2mi
-          image: {{ .Values.containerRegistry }}/{{ .Values.wso2.deployment.image.repository }}{{- if .Values.wso2.deployment.image.digest }}@{{ .Values.wso2.deployment.image.digest }}{{- else }}:{{ .Values.wso2.deployment.image.tag }}{{- end }}
+          image: "{{- if .Values.containerRegistry -}}{{ .Values.containerRegistry }}/{{ end }}{{ .Values.wso2.deployment.image.repository }}{{- if .Values.wso2.deployment.image.digest -}}@{{ .Values.wso2.deployment.image.digest }}{{- else -}}:{{ .Values.wso2.deployment.image.tag }}{{- end }}"
           imagePullPolicy: {{ .Values.wso2.deployment.image.pullPolicy }}
           args:
             {{- if .Values.wso2.deployment.synapseTest.enabled }}

--- a/mi/templates/mi-metrics-ingress.yaml
+++ b/mi/templates/mi-metrics-ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.wso2.ingress.metrics }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "resource.prefix" . }}-{{ .Release.Name }}-metrics
+  namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.ingress.metrics.annotations }}
+  annotations:
+{{ toYaml .Values.wso2.ingress.metrics.annotations | indent 4 }}
+{{- if .Values.wso2.ingress.ratelimit.enabled }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      limit_req zone={{ .Values.wso2.ingress.ratelimit.zoneName }} burst={{ .Values.wso2.ingress.ratelimit.burstLimit }} nodelay;                                                   
+      limit_req_status 429;
+{{- end }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.wso2.ingress.ingressClassName }}
+  tls:
+    - hosts:
+      - {{ .Values.wso2.deployment.hostname | quote }}
+      secretName: {{ .Values.wso2.ingress.tlsSecret }}
+  rules:
+    - host: {{ .Values.wso2.deployment.hostname | quote }}
+      http:
+        paths:
+          - path: /healthz
+            pathType: Exact
+            backend:
+              service:
+                name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
+                port:
+                  number: {{ add 9201 .Values.wso2.config.portOffset -10 }}
+{{- end}}

--- a/mi/templates/mi-secrets.yaml
+++ b/mi/templates/mi-secrets.yaml
@@ -1,0 +1,27 @@
+{{ if and .Values.wso2.subscription.username .Values.wso2.subscription.password }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- $username := .Values.wso2.subscription.username }}
+{{- $password := .Values.wso2.subscription.password }}
+{{- $email := .Values.wso2.subscription.username }}
+{{- $regId := .Values.containerRegistry }}
+{{- $auth := printf "%s:%s" $username $password | b64enc }}
+{{- $files := .Files }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wso2micro-integrator-deployment-creds
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $files.Get "auth.json" | replace "reg.id" $regId | replace "reg.username" $username | replace "reg.password" $password | replace "reg.email" $email | replace "reg.auth" $auth | b64enc }}
+{{ end }}

--- a/mi/templates/mi-secrets.yaml
+++ b/mi/templates/mi-secrets.yaml
@@ -1,14 +1,22 @@
 {{ if and .Values.wso2.subscription.username .Values.wso2.subscription.password }}
-# -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained 
-# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
-# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
 #
-# --------------------------------------------------------------------------------------
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 
 {{- $username := .Values.wso2.subscription.username }}
 {{- $password := .Values.wso2.subscription.password }}

--- a/mi/values.yaml
+++ b/mi/values.yaml
@@ -1,6 +1,6 @@
 # -- Kubernetes cluster provider. Supported values: azure, aws
 provider: ""
-# -- Container registry
+# -- Container registry (When running on a local Kubernetes cluster, make this empty)
 containerRegistry: "docker.wso2.com"
 # AWS service configurations
 aws:

--- a/mi/values.yaml
+++ b/mi/values.yaml
@@ -1,10 +1,10 @@
 # -- Kubernetes cluster provider. Supported values: azure, aws
 provider: ""
 # -- Container registry
-containerRegistry: ""
+containerRegistry: "docker.wso2.com"
 # AWS service configurations
 aws:
-  # -- AWS IAM serivce account name
+  # -- AWS IAM service account name
   serviceAccountName: ""
   # -- AWS region
   region: ""
@@ -42,6 +42,11 @@ azure:
       # -- Name of the Azure Resource Group to which the target Azure Key Vault belongs
       resourceGroup: ""
 wso2:
+  subscription:
+    # -- WSO2 subscription username
+    username: ""
+    # -- WSO2 subscription password
+    password: ""
   ingress:
     # -- Enable Ingress for MI
     enabled: true
@@ -82,45 +87,49 @@ wso2:
         # -- Primary keystore alias
         alias: "wso2carbon"
         # -- Primary keystore password
-        password: ""
+        password: "wso2carbon"
         # -- Primary keystore key password
-        keyPassword: ""
+        keyPassword: "wso2carbon"
       internal:
         # -- Internal keystore file name
         fileName: "wso2carbon.jks"
         # -- Internal keystore alias
         alias: "wso2carbon"
         # -- Internal keystore password
-        password: ""
+        password: "wso2carbon"
         # -- Internal keystore key password
-        keyPassword: ""
+        keyPassword: "wso2carbon"
     trustStore:
       primary:
         # -- Primary truststore file name
         fileName: "client-truststore.jks"
         # -- Primary truststore password
-        password: ""
+        password: "wso2carbon"
   deployment:
     securityContext:
       # -- Enable/Disable AppArmor (https://kubernetes.io/docs/tutorials/security/apparmor/)
-      apparmor: true
+      apparmor: false
       # -- Enable/Disable seccomp profile (https://kubernetes.io/docs/tutorials/security/seccomp/)
       seccompProfile: true
       # -- The UID to run the entrypoint of the container process
       runAsUser: ""
     # -- Hostname of the Micro Integrator deployment
-    hostname: ""
+    hostname: "mi.wso2.com"
     # -- Build version of the Micro Integrator
-    BuildVersion: "4.2.0"
+    BuildVersion: "4.3.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
+    # -- imagePullSecrets for private docker registry
+    imagePullSecrets: ""
     image:
       # -- Container image repository name
-      repository: ""
+      repository: "wso2mi"
       # -- Container image digest
       digest: ""
+      # -- Container image tag
+      tag: "4.3.0"
       # -- Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
 
     # -- Kubernetes Probes (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
     probes:

--- a/mi/values_full.yaml
+++ b/mi/values_full.yaml
@@ -4,7 +4,7 @@ provider: ""
 containerRegistry: ""
 # AWS service configurations
 aws:
-  # -- AWS IAM serivce account name
+  # -- AWS IAM service account name
   serviceAccountName: ""
   # -- AWS region
   region: ""
@@ -82,6 +82,11 @@ gcp:
       # -- Pre-provisioned Filestore instance share name
       volume: ""
 wso2:
+  subscription:
+    # -- WSO2 subscription username
+    username: ""
+    # -- WSO2 subscription password
+    password: ""
   ingress:
     # -- Enable Ingress for MI
     enabled: true
@@ -585,11 +590,15 @@ wso2:
     BuildVersion: "4.2.0"
     # -- K8s secret name which contains JKS files
     JKSSecretName: ""
+    # -- imagePullSecrets for private docker registry
+    imagePullSecrets: ""
     image:
       # -- Container image repository name
       repository: ""
       # -- Container image digest
       digest: ""
+      # -- Container image tag
+      tag: ""
       # -- Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       pullPolicy: Always
 

--- a/mi/values_local.yaml
+++ b/mi/values_local.yaml
@@ -1,46 +1,6 @@
-# -- Kubernetes cluster provider. Supported values: azure, aws
-provider: ""
 # -- Container registry (When running on a local Kubernetes cluster using local image, make this empty)
 containerRegistry: "wso2"
-# AWS service configurations
-aws:
-  # -- AWS IAM service account name
-  serviceAccountName: ""
-  # -- AWS region
-  region: ""
-  # AWS Secret Manager configurations
-  secretManager:
-    # -- AWS Secret Manager secret provider class name
-    secretProviderClass: ""
-    secretIdentifiers:
-      internalKeystorePassword:
-        # -- Secret name for internal keystore password
-        secretName: ""
-        # -- Secret key for internal keystore password
-        secretKey: ""
-# Azure service configurations
-azure:
-  keyVault:
-    # -- Name of the target Azure Key Vault instance
-    name: ""
-    secretProviderClass: ""
-    secretIdentifiers:
-      internalKeystorePassword: ""
-    activeDirectory:
-      # -- Service Principal created for transacting with the target Azure Key Vault
-      # For advanced details refer to official documentation (https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/docs/service-principal-mode.md)
-      servicePrincipal:
-        # -- Azure AD application name for fetching secrets via CSI secret store driver
-        appId: ""
-        # -- Client secret of Azure AD application client
-        clientSecret: ""
-      # -- Azure Active Directory tenant ID of the target Key Vault
-      tenantId: ""
-    resourceManager:
-      # -- Subscription ID of the target Azure Key Vault
-      subscriptionId: ""
-      # -- Name of the Azure Resource Group to which the target Azure Key Vault belongs
-      resourceGroup: ""
+
 wso2:
   subscription:
     # -- WSO2 subscription username
@@ -65,9 +25,9 @@ wso2:
       # -- Ingress ratelimit burst limit
       burstLimit: ""
       # -- Enable Ingress for metrics
-      metrics:
-        annotations:
-          nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    metrics:
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
   config:
     # -- Port offset for Micro Integrator (https://apim.docs.wso2.com/en/latest/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-mi-ports)
     portOffset: 10

--- a/mi/values_local.yaml
+++ b/mi/values_local.yaml
@@ -1,7 +1,7 @@
 # -- Kubernetes cluster provider. Supported values: azure, aws
 provider: ""
 # -- Container registry (When running on a local Kubernetes cluster using local image, make this empty)
-containerRegistry: "docker.wso2.com"
+containerRegistry: "wso2"
 # AWS service configurations
 aws:
   # -- AWS IAM service account name
@@ -51,9 +51,10 @@ wso2:
     # -- Enable Ingress for MI
     enabled: true
     # -- Ingress class name
-    ingressClassName: ""
+    ingressClassName: "nginx"
     # -- (list) Ingress annotations
     annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     # -- K8s TLS secret for configured hostname
     tlsSecret: ""
     ratelimit:
@@ -63,6 +64,10 @@ wso2:
       zoneName: ""
       # -- Ingress ratelimit burst limit
       burstLimit: ""
+      # -- Enable Ingress for metrics
+      metrics:
+        annotations:
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
   config:
     # -- Port offset for Micro Integrator (https://apim.docs.wso2.com/en/latest/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-mi-ports)
     portOffset: 10
@@ -87,32 +92,32 @@ wso2:
         # -- Primary keystore alias
         alias: "wso2carbon"
         # -- Primary keystore password
-        password: ""
+        password: "wso2carbon"
         # -- Primary keystore key password
-        keyPassword: ""
+        keyPassword: "wso2carbon"
       internal:
         # -- Internal keystore file name
         fileName: "wso2carbon.jks"
         # -- Internal keystore alias
         alias: "wso2carbon"
         # -- Internal keystore password
-        password: ""
+        password: "wso2carbon"
         # -- Internal keystore key password
-        keyPassword: ""
+        keyPassword: "wso2carbon"
     trustStore:
       primary:
         # -- Primary truststore file name
         fileName: "client-truststore.jks"
         # -- Primary truststore password
-        password: ""
+        password: "wso2carbon"
   deployment:
     securityContext:
       # -- Enable/Disable AppArmor (https://kubernetes.io/docs/tutorials/security/apparmor/)
-      apparmor: true
+      apparmor: false
       # -- Enable/Disable seccomp profile (https://kubernetes.io/docs/tutorials/security/seccomp/)
-      seccompProfile: true
+      seccompProfile: false
       # -- The UID to run the entrypoint of the container process
-      runAsUser: ""
+      runAsUser: "802"
     # -- Hostname of the Micro Integrator deployment
     hostname: "mi.wso2.com"
     # -- Build version of the Micro Integrator


### PR DESCRIPTION
## Purpose
Add wso2 subscription credentials and docker image tag.

Now user can add wso2 subscription credentials for pull docker images from `docker.wso2.com`. 
User can use digest or tag. when both are provided digest has high priority. 

```yaml
wso2:
    subscription:
        username: "<username>"
        password: "<password>"
    deployment:
        image:
            repository: ""
            digest: ""
            tag: ""
```