### PR TITLE
Add option to set nodeSelector

### DIFF
--- a/mi/CONFIG.md
+++ b/mi/CONFIG.md
@@ -295,6 +295,7 @@ A Helm chart for the deployment of WSO2 Micro Integrator
 | wso2.deployment.image.pullPolicy | string | `"Always"` | Container image pull policy. Refer (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | wso2.deployment.image.repository | string | `""` | Container image repository name |
 | wso2.deployment.mountCapps | bool | `false` | Incase the CApps are not burned into the docker image, set the following to `true` to mount the CApps using a persistent volume |
+| wso2.deployment.nodeSelector | object | `{"key":"value"}` | Node selector for the Micro Integrator deployment |
 | wso2.deployment.pdb | object | `{"enabled":false,"minAvailable":1}` | Pod disruption budget configurations (https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | wso2.deployment.pdb.enabled | bool | `false` | Enable/Disable pod disruption budget |
 | wso2.deployment.pdb.minAvailable | int | `1` | Min available pods for pod disruption budget |

--- a/mi/templates/mi-deployment.yaml
+++ b/mi/templates/mi-deployment.yaml
@@ -58,6 +58,10 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      {{- with .Values.wso2.deployment.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/mi/templates/mi-deployment.yaml
+++ b/mi/templates/mi-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         {{- end }}
       {{- with .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/mi/values_full.yaml
+++ b/mi/values_full.yaml
@@ -653,7 +653,10 @@ wso2:
       enabled: false
       # -- Min available pods for pod disruption budget
       minAvailable: 1
-
+    # -- Node selector for the Micro Integrator deployment
+    nodeSelector:
+      # Key-value pairs to select nodes for pod assignment
+      key: value
     strategy:
       rollingUpdate:
         # -- The maximum number of pods that can be scheduled above the desired number of pods.


### PR DESCRIPTION
## Purpose

Add support to configure nodeSelector. You can define the required key–value pairs for the nodeSelector in the values.yaml file as follows:

```yaml
wso2:
  deployment:
    nodeSelector:
      zone: az2
```

Fixes: https://github.com/wso2/product-micro-integrator/issues/4664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Kubernetes health checks: liveness, readiness and startup probes can now be tuned with failure thresholds, initial delays and probe intervals to improve pod lifecycle handling.
  * Node selector support: pods can be scheduled to specific nodes using a configurable node selector to control placement and resource locality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->