### PR TITLE
Add conditional guard in icp-ingress template

### DIFF
--- a/icp/templates/icp-ingress.yaml
+++ b/icp/templates/icp-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.wso2.ingress.enabled }}
 # ------------------------------------------------------------------------------------
 # Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
 #
@@ -47,3 +48,4 @@ spec:
                 name: {{ template "resource.prefix" . }}-{{ .Release.Name }}
                 port:
                   number: {{ .Values.wso2.config.serverPort }}
+{{- end }}


### PR DESCRIPTION
## Purpose
Add missing `{{- if .Values.wso2.ingress.enabled }}` conditional guard to `icp/templates/icp-ingress.yaml` to prevent the Ingress resource from being created when ingress is disabled in `values.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Ingress resource deployment is now configurable and can be disabled via settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->