### PR TITLE
Remove unused loggers

### DIFF
--- a/mi/confs/log4j2.properties
+++ b/mi/confs/log4j2.properties
@@ -313,10 +313,6 @@ logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
 logger.org-apache-axis2-clustering.level = INFO
 logger.org-apache-axis2-clustering.additivity = false
 
-logger.org-apache.name = org.apache
-logger.org-apache.level = INFO
-logger.org-apache.additivity = false
-
 logger.org-apache-catalina.name = org.apache.catalina
 logger.org-apache-catalina.level = ERROR
 
@@ -375,9 +371,6 @@ logger.org-apache-solr.level = ERROR
 
 logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
 logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
-
-logger.org-wso2.name = org.wso2
-logger.org-wso2.level = ERROR
 
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL

--- a/mi/values_local.yaml
+++ b/mi/values_local.yaml
@@ -187,3 +187,6 @@ wso2:
     synapseTest:
       # -- Enable/Disable synapse testing
       enabled: false
+    configMaps:
+      entryPoint:
+        defaultMode: "0755"


### PR DESCRIPTION
## Purpose

Remove unused loggers. With the latest Log4j2 upgrades, the server may throw Pax Logging–related errors due to dangling logger configurations. Therefore, these unused loggers need to be removed from the l`og4j2.properties` file used in our Helm charts.

## Related PR

https://github.com/wso2/product-integrator-mi/pull/4634