### PR TITLE
Fix ICP version reference in README from v1.2.0 to v2.0.0

### DIFF
--- a/icp/README.md
+++ b/icp/README.md
@@ -1,6 +1,6 @@
-# Helm chart for the deployment of WSO2 Integration Control Plane (ICP) - v1.2.0
+# Helm chart for the deployment of WSO2 Integration Control Plane (ICP) - v2.0.0
 
-This module contains the Helm resources required to deploy WSO2 Integration Control Plane (ICP) v1.2.0 in a Kubernetes environment.
+This module contains the Helm resources required to deploy WSO2 Integration Control Plane (ICP) v2.0.0 in a Kubernetes environment.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- The ICP README heading and description incorrectly referenced version `v1.2.0` instead of `v2.0.0`.
- Updated both lines to match the actual chart `appVersion` and image tag (`2.0.0`).

## Test plan
- [x] Verify README heading reads `v2.0.0`
- [x] Verify README description reads `v2.0.0`