### PR TITLE
Add storage.deploymentType support and fix Gateway API setup instructions

### DIFF
--- a/icp/README.md
+++ b/icp/README.md
@@ -1,6 +1,6 @@
-# Helm chart for the deployment of WSO2 Integration Control Plane (ICP) - v1.2.0
+# Helm chart for the deployment of WSO2 Integration Control Plane (ICP) - v2.0.0
 
-This module contains the Helm resources required to deploy WSO2 Integration Control Plane (ICP) v1.2.0 in a Kubernetes environment.
+This module contains the Helm resources required to deploy WSO2 Integration Control Plane (ICP) v2.0.0 in a Kubernetes environment.
 
 ## Prerequisites
 

--- a/icp/confs/deployment.toml
+++ b/icp/confs/deployment.toml
@@ -278,6 +278,9 @@ artifactsApiAllowInsecureTLS = {{ .Values.wso2.config.artifactsApiAllowInsecureT
 # =============================================================================
 [icp_server.storage]
 {{- if .Values.wso2.config.storage }}
+{{- if .Values.wso2.config.storage.deploymentType }}
+deploymentType = {{ .Values.wso2.config.storage.deploymentType | quote }}
+{{- end }}
 {{- if .Values.wso2.config.storage.heartbeatTimeoutSeconds }}
 heartbeatTimeoutSeconds = {{ .Values.wso2.config.storage.heartbeatTimeoutSeconds }}
 {{- end }}

--- a/icp/templates/NOTES.txt
+++ b/icp/templates/NOTES.txt
@@ -44,7 +44,7 @@ IMPORTANT: Before HTTPRoute can work, ensure the following prerequisites are met
 
 {{- if .Values.wso2.gatewayAPI.createGateway }}
 
-3. A GatewayClass "{{ .Values.wso2.gatewayAPI.gatewayClassName }}" must exist:
+2. A GatewayClass "{{ .Values.wso2.gatewayAPI.gatewayClassName }}" must exist:
    kubectl get gatewayclass {{ .Values.wso2.gatewayAPI.gatewayClassName }}
 
 Gateway resource created by this chart:
@@ -54,7 +54,7 @@ Gateway resource created by this chart:
 
 {{- else }}
 
-3. An external Gateway resource must exist:
+2. An external Gateway resource must exist:
    kubectl get gateway {{ .Values.wso2.gatewayAPI.gatewayName }} -n {{ .Values.wso2.gatewayAPI.gatewayNamespace }}
 
 External Gateway:

--- a/icp/templates/NOTES.txt
+++ b/icp/templates/NOTES.txt
@@ -29,19 +29,16 @@ You have enabled Gateway API for traffic routing.
 
 IMPORTANT: Before HTTPRoute can work, ensure the following prerequisites are met:
 
-1. Gateway API CRDs must be installed:
-   kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io
-
-   If not installed, run:
-   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
-
-2. A Gateway Controller must be running:
+1. A Gateway Controller must be running:
    For Envoy Gateway (default):
      kubectl get pods -n envoy-gateway-system
 
-   To install Envoy Gateway:
+   To install Envoy Gateway (this also installs Gateway API CRDs automatically):
      helm install eg oci://docker.io/envoyproxy/gateway-helm \
-       --version v1.7.0 -n envoy-gateway-system --create-namespace
+       --version v1.2.1 -n envoy-gateway-system --create-namespace
+
+   NOTE: Do not pre-install Gateway API CRDs separately — Envoy Gateway's Helm
+   chart manages them. Pre-installing with kubectl causes a CRD ownership conflict.
 
    For other controllers, see EXAMPLES.md for configuration and installation guidance.
 

--- a/icp/values.yaml
+++ b/icp/values.yaml
@@ -166,7 +166,9 @@ wso2:
     # Credentials database configuration
     credentialsDb: {}
     # Primary database / storage configuration
-    storage: {}
+    storage:
+      # -- Deployment type for runtime discovery. "K8S" enables Kubernetes-native MI pod discovery; "VM" for static/VM deployments.
+      deploymentType: ""
     # SSO (OIDC) configuration
     sso:
       # -- Enable/Disable SSO authentication

--- a/icp/values_local.yaml
+++ b/icp/values_local.yaml
@@ -51,7 +51,7 @@ wso2:
     # -- Name of the Gateway
     gatewayName: "wso2-gateway-icp"
     # -- Namespace where the Gateway resides
-    gatewayNamespace: "default"
+    gatewayNamespace: "icp"
     # TLS secret for Gateway HTTPS listener
     # If tlsSecret is empty, a self-signed TLS certificate will be generated automatically for local/dev use.
     # MANDATORY : For production, provide a cert-manager managed secret via tlsSecret.
@@ -97,13 +97,14 @@ wso2:
     # -- Authentication backend URL
     authBackendUrl: "https://localhost:9447"
     # -- Frontend JWT HMAC secret (at least 32 characters for HS256)
-    frontendJwtHMACSecret: ""
+    frontendJwtHMACSecret: ""  # Set to a random string of at least 32 chars (e.g., openssl rand -base64 32)
     # -- Allow insecure TLS for MI artifacts API
     artifactsApiAllowInsecureTLS: false
     # Credentials database configuration
     credentialsDb: {}
     # Primary database / storage configuration
-    storage: {}
+    storage:
+      deploymentType: "K8S"
     # SSO (OIDC) configuration
     sso:
       # -- Enable/Disable SSO authentication


### PR DESCRIPTION
## Summary

- **Add `storage.deploymentType` to ICP Helm chart** — exposes the `deploymentType` field in `[icp_server.storage]` so ICP can be configured for Kubernetes-native MI pod discovery (`K8S`) or static VM/Docker deployments (`VM`). Previously this field was recognized by the ICP application but had no corresponding Helm value.

- **Fix NOTES.txt Gateway API instructions** — removes the incorrect step to pre-install Gateway API CRDs with `kubectl apply`, which causes a CRD ownership conflict when Envoy Gateway is subsequently installed via Helm. Envoy Gateway's Helm chart manages the CRDs natively. Also corrects the Envoy Gateway version from `v1.7.0` to `v1.2.1`.

- **Fix `values_local.yaml` gateway namespace** — sets `gatewayNamespace: "icp"` (matching the release namespace) so the Gateway and TLS secret are co-located, avoiding a cross-namespace `ReferenceGrant` requirement for the HTTPS listener.

## Usage

```yaml
wso2:
  config:
    storage:
      deploymentType: "K8S"  # or "VM" for non-Kubernetes deployments
```

## Test plan

- [ ] Verify `deploymentType = "K8S"` appears in the rendered `deployment.toml` (`kubectl exec ... -- grep deploymentType conf/deployment.toml`)
- [ ] Verify `storage.deploymentType` is omitted from the config when left empty (default)
- [ ] Verify Envoy Gateway installs cleanly without pre-installing Gateway API CRDs
- [ ] Verify HTTPS listener on Gateway becomes `Programmed` when TLS secret is in the same namespace as the Gateway