### PR TITLE
Default storage.deploymentType to K8S in ICP Helm chart

### DIFF
--- a/icp/values.yaml
+++ b/icp/values.yaml
@@ -168,7 +168,7 @@ wso2:
     # Primary database / storage configuration
     storage:
       # -- Deployment type for runtime discovery. "K8S" enables Kubernetes-native MI pod discovery; "VM" for static/VM deployments.
-      deploymentType: ""
+      deploymentType: "K8S"
     # SSO (OIDC) configuration
     sso:
       # -- Enable/Disable SSO authentication


### PR DESCRIPTION
## Summary

Since the ICP Helm chart is exclusively deployed on Kubernetes, default `storage.deploymentType` to `"K8S"` so users get Kubernetes-native runtime discovery out of the box without any extra configuration.

Previously `deploymentType` was introduced with an empty default (PR #41), requiring an explicit `--set wso2.config.storage.deploymentType=K8S`. A plain `helm install icp icp/ -n icp --values icp/values.yaml` now renders `deploymentType = "K8S"` in `deployment.toml` automatically.

Users on VM/Docker deployments can still override with `--set wso2.config.storage.deploymentType=VM`.

## Test plan

- [ ] Verify `deploymentType = "K8S"` appears in `deployment.toml` with a default install (no extra `--set` flags)
- [ ] Verify override to `VM` works: `helm install ... --set wso2.config.storage.deploymentType=VM`